### PR TITLE
samizdat-up self_update brew-path fix, publish workflow submodule fast-forward, bump to 0.3.2

### DIFF
--- a/.github/workflows/publish-get-samizdat.yaml
+++ b/.github/workflows/publish-get-samizdat.yaml
@@ -56,10 +56,24 @@ jobs:
       # git@github.com:`, which converts the submodule's SSH URL to
       # HTTPS and skips our deploy key. Drop the rewrite, fetch
       # manually.
+      #
+      # After init, fast-forward the submodule to its remote `main`
+      # HEAD. The parent repo's recorded submodule SHA only advances
+      # when someone explicitly commits the pointer here, which the
+      # publish workflow does NOT do (it commits + pushes the
+      # submodule's own main directly). Skipping this pull would
+      # check out a stale snapshot of dist/ that's missing every
+      # version published since the parent's submodule pointer was
+      # last touched, and the surgical wipe step would carry that
+      # stale state forward, silently dropping versions from the
+      # signed inventory.
       - name: Fetch get-samizdat submodule over SSH
         run: |
           git config --global --unset-all url.https://github.com/.insteadOf || true
           git submodule update --init --recursive
+          git -C install/get-samizdat fetch origin main
+          git -C install/get-samizdat checkout main
+          git -C install/get-samizdat pull --ff-only origin main
 
       - name: Install Rust toolchain + cross targets
         uses: dtolnay/rust-toolchain@nightly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # Agent orientation
 
 Samizdat is a peer-to-peer, content-addressed publishing network with Ethereum-based
-identity. The workspace has five Rust crates: `common`, `node`, `hub`, `cli`, `proxy`.
-This file tells you (the agent) where to look first.
+identity. The workspace has six Rust crates: `common`, `node`, `hub`, `cli`, `proxy`,
+and `samizdat-up` (the installer/updater). This file tells you (the agent) where to
+look first.
 
 ## Read these before doing anything substantial
 
@@ -56,6 +57,23 @@ human's agent. The TL;DR for agents that don't have access to that memory:
   tests across `common`, `hub`, and `node`.
 - DB tests use the `samizdat-common` `test-helpers` feature. See
   `docs/conventions.md` for the `TestDb<T>` pattern.
+
+## Common commands
+
+- Build/check everything: `cargo check --workspace` (fast) or
+  `cargo build --workspace` (binaries land in `target/debug/`).
+- Run all tests: `cargo test --workspace`. Don't run this after every edit
+  (see Working preferences); the suite is slow, batch and validate once.
+- Run one crate's tests: `cargo test -p samizdat-node`.
+- Run a single test by name substring: `cargo test -p samizdat-node
+  <test_name>` (add `-- --nocapture` to see prints).
+- Format: `cargo fmt`. Lint: `cargo clippy --workspace`.
+- Release builds use `release.sh <new-version>` (bumps the workspace version,
+  tags, pushes, triggers the publish workflow). Read `docs/operations.md`
+  before cutting a release.
+- The `js/` library (SamizdatJS) is a separate npm project: `cd js && npm
+  install`, then `npm run build` (webpack) or `npm run serve` (dev server).
+  It has no test suite.
 
 ## Conventions that are easy to miss
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "samizdat"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "askama",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "samizdat-common"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes-gcm-siv",
  "base64-url",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "samizdat-hub"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "bincode",
@@ -4575,7 +4575,7 @@ dependencies = [
 
 [[package]]
 name = "samizdat-node"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes-gcm-siv",
  "askama",
@@ -4617,7 +4617,7 @@ dependencies = [
 
 [[package]]
 name = "samizdat-proxy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "askama",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "samizdat-up"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap 4.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Pedro B Arruda <pedrobittencourt3@gmail.com>"]
 edition = "2024"
 

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,129 @@
+# Samizdat: your content, available.
+
+[![Continuous Integration](https://github.com/tokahuke/samizdat/actions/workflows/test-samizdat-up.yaml/badge.svg?branch=main)](https://github.com/tokahuke/samizdat/actions/workflows/test-samizdat-up.yaml)
+![Version 0.3.1](https://img.shields.io/badge/version-0.3.1-informational)
+
+## Website
+
+Samizdat is pulling itself by its bootstraps!
+https://proxy.hubfederation.com/~samizdat
+
+## Donate
+
+If you support this work, consider donating using crypto
+
+| Currency | Address                                      |
+|----------|----------------------------------------------|
+| `XMR`    | `86YcEFJSQXfZbPhjpDpabb5raQjVLWAfji3eMGebbj6QJnk1wXfgfqx9pgqURUWqMbjW7mNTC79guNEEsGPKJbRGKxEkrAN` |
+| `BTC`    | `bc1qseae89zr4z2lkl82nvvr6c9sl97agshapzeag5` |
+| `ETH`    | `0xba89B660eB6f5D894830C9273a5Dfb8dDc170cff` |
+
+
+## Introduction
+
+In these troubling times, some people might find it hard to publish content to the web. Samizdat is a P2P network for sharing and publishing content without the need of a server, most of which are run by _them_. Self-publish your content today with Samizdat!
+
+### Warning
+
+This is still a proof of concept implementation. So three caveats are in place:
+
+1. Don't rely on the availability of the network or of your content; have alternatives in place.
+2. Expect frequent breaking changes.
+3. Expect vulnerabilities. Do not use the network for sensitive content yet.
+
+> How to make this warning disappear? Contribute! I am but one humble human being.
+
+## Project goals
+
+Samizdat (from a Russian term meaning "self-publishing") aims to provide a decentralized internet application that enables one to do the following:
+
+1. Be able to allow one to serve a public, static site without the need for a hosting service. The content is to be hosted in the person's own device or in caches from people who visit the site. (READY)
+
+2. Provide a human-friendly identifier for resources contained in this network, i.e., a URL scheme. This URL is to be content-addressed, not location-addressed. (IN CONSTRUCTION)
+
+3. Oblivious hosting: only the device serving the content and the device asking for the content can extract any information about the content or its metadata. (BY DESIGN)
+
+4. Do all this _easily_ and _conveniently_. Graphical interfaces, mobile apps and amenities are welcome. (IN CONSTRUCTION)
+
+We are not quite there yet...
+
+## 📢 Help wanted! 🗯
+
+These are important issues where help is most appreciated:
+
+* **Android support**: make Samizdat Node run on Android.
+    * Why it matters: this is an end-user product and most end-users are on mobile.
+    * Why it's hard: I'm bored by Android development. (Linux, macOS and Windows are
+      already supported via `samizdat-up`.)
+
+## Architecture
+
+The project uses a hybrid peer-to-peer network, where nodes connect to hubs. The nodes are the consumers and producers of content; all content transmission is handled by the nodes. The hubs are used for routing, discovery and NAT traversal. One node can connect to many hubs simultaneously so that content can diffuse through different tribes with time.
+
+For a deeper tour of the crates and concepts, see [docs/architecture.md](docs/architecture.md).
+
+## Installation
+
+The recommended path is the `samizdat-up` bootstrap installer, which downloads the
+latest release from the network itself and then installs the node, hub or proxy as
+a system service. On Linux and macOS:
+
+```
+curl -fsSL https://proxy.hubfederation.com/~get-samizdat/latest/install.sh | sudo bash
+sudo samizdat-up install node
+```
+
+On Windows, download `samizdat-up.exe` from the same location and run
+`samizdat-up install node` from an elevated shell. See
+[docs/operations.md](docs/operations.md) for the testbed runbook.
+
+## Quick start
+
+In the installation, the `samizdat` cli tool is included. You can run `samizdat init` to create a new Samizdat project in your current directory. This will create a manifest file `Samizdat.toml` and a private manifest `.Samizdat.priv`, which will be added to your `.gitignore`. This file contains private credentials that you have to backup elsewhere dearly.
+
+In your local node, this will also create a new _series_, your very own microblog/directory in the Samizdat Network. To refresh the contents of your series, just do `samizdat commit` (or even better, `samizdat watch` for continuous refresh-on-save). Samizdat will run a build script that you supply in `Samizdat.toml`. Your content will be available in the URL:
+
+```
+http://localhost:4510/~<series name>/path/to/stuff
+```
+
+Despite the `localhost`, this is a public URL. You can share it with friends that
+have Samizdat installed and they will be able to access it.
+
+This is just the tip of the iceberg, however! Check out more under
+[docs/](docs/) in this repository.
+
+
+## Repository structure
+
+* `common`: Rust lib defining common code shared by other Samizdat crates. You will find here RPC definitions, Merkle tree implementation, etc...
+* `hub`: the Samizdat Hub crate.
+* `node`: the Samizdat Node crate.
+* `cli`: the Samizdat CLI crate.
+* `proxy`: a proxy to bridge a Samizdat Node to the open Web, used in [https://proxy.hubfederation.com](https://proxy.hubfederation.com).
+* `samizdat-up`: cross-platform installer / service manager (systemd, launchd, Windows SCM).
+* `js`: the SamizdatJS library, which enables Web applications to interface with the local Samizdat node.
+* `install`: installation artifacts for end users on different platforms.
+* `simulate-net`: spawn your own network locally. Necessary for integration tests.
+* `blockchain`: smart contracts for the Samizdat identity.
+* `terraform`: infrastructure-as-code for the public testbed.
+* `docs`: architecture, threat model, conventions and operations runbook.
+
+## Licensing
+
+All code under the Samizdat Project is Free Software and is licensed to any individual or
+    organization under the AGPLv3 license. You are free to run, study, alter and redistribute
+    the software as you wish, as long as you abide by the terms of the aforementioned license.
+
+Copyright 2021-2026 Tokahuke
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details. The text of this license
+can be found in the [license](./license) file in this repository.

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Samizdat: your content, available.
 
 [![Continuous Integration](https://github.com/tokahuke/samizdat/actions/workflows/test-samizdat-up.yaml/badge.svg?branch=main)](https://github.com/tokahuke/samizdat/actions/workflows/test-samizdat-up.yaml)
-![Version 0.3.1](https://img.shields.io/badge/version-0.3.1-informational)
+![Version 0.3.2](https://img.shields.io/badge/version-0.3.2-informational)
 
 ## Website
 

--- a/samizdat-up/src/install/linux.rs
+++ b/samizdat-up/src/install/linux.rs
@@ -168,12 +168,18 @@ pub(super) fn installed_binary_paths() -> Vec<(&'static str, PathBuf)> {
 }
 
 pub(super) fn self_update() -> Result<()> {
-    require_root()?;
+    // No `require_root()`: who needs root depends on who owns the
+    // currently-running samizdat-up binary. Brew installs land under
+    // a user-owned prefix (e.g. /opt/homebrew/bin); a bootstrap
+    // curl-pipe-sh install lands under /usr/local/bin (root-owned).
+    // We write back to wherever current_exe() resolves to and let
+    // the OS surface permission errors verbatim.
     let origin = DEFAULT_ORIGIN.to_owned();
     let target = fetch::host_target_triple();
     let fetched = fetch::fetch_file(&origin, "latest", target, "samizdat-up", "samizdat-up")
         .context("fetching new samizdat-up")?;
-    let dest = PathBuf::from("/usr/local/bin/samizdat-up");
+    let dest = std::env::current_exe()
+        .context("locating current samizdat-up binary")?;
 
     // Stage the new binary in a sibling file, run `--version` on it,
     // and only swap if it answers cleanly. Catches mismatched-arch

--- a/samizdat-up/src/install/macos.rs
+++ b/samizdat-up/src/install/macos.rs
@@ -202,12 +202,18 @@ pub(super) fn installed_binary_paths() -> Vec<(&'static str, PathBuf)> {
 }
 
 pub(super) fn self_update() -> Result<()> {
-    require_root()?;
+    // No `require_root()`: who needs root depends on who owns the
+    // currently-running samizdat-up binary. On Apple Silicon, brew
+    // installs land under /opt/homebrew/bin (user-owned); a
+    // bootstrap curl-pipe-sh install lands at /usr/local/bin
+    // (root-owned). Resolve the destination via current_exe() and
+    // let the OS surface permission errors verbatim.
     let origin = DEFAULT_ORIGIN.to_owned();
     let target = fetch::host_target_triple();
     let fetched = fetch::fetch_file(&origin, "latest", target, "samizdat-up", "samizdat-up")
         .context("fetching new samizdat-up")?;
-    let dest = PathBuf::from("/usr/local/bin/samizdat-up");
+    let dest = std::env::current_exe()
+        .context("locating current samizdat-up binary")?;
 
     let staged = dest.with_extension("samizdat-up-new");
     atomic_write_executable(&staged, &fetched.bytes)


### PR DESCRIPTION
## Summary

- `samizdat-up self_update` now writes to `current_exe()` instead of the hard-coded `/usr/local/bin/samizdat-up`, so brew-installed binaries (user-owned prefix on Apple Silicon and Linux) can update themselves without `require_root()`. OS surfaces permission errors verbatim.
- `publish-get-samizdat` workflow fast-forwards the `get-samizdat` dist submodule to its remote `main` HEAD after `submodule update --init`. The parent pointer only advances when someone explicitly commits the submodule SHA, which the publish workflow does NOT do (it pushes directly to the submodule's main). Without the fast-forward the surgical wipe step would carry stale state forward and silently drop versions from the signed inventory.
- Bumps workspace version to `0.3.2` (covers both user-visible install behavior and the published-dist-tree fix).

## Test plan

- [x] `cargo check --workspace` passes
- [ ] `test-samizdat-up.yaml` matrix is green on CI
- [ ] Docker smoke test: install from a fresh container against the public `~get-samizdat` testbed